### PR TITLE
Bug/fix TypeError BaseBuilder::orderBy()

### DIFF
--- a/Datatables.php
+++ b/Datatables.php
@@ -107,9 +107,9 @@ class Datatables{
 	}
 
 	private function getOrdering(){
-		$orderField = esc($this->request->getPost('order')[0]['column']);
-		$orderAD = esc($this->request->getPost('order')[0]['dir']);
-		$orderColumn = esc($this->request->getPost('columns')[$orderField]['data']);
+		$orderField = esc($this->request->getPost('order')[0]['column']) ?? "";
+		$orderAD = esc($this->request->getPost('order')[0]['dir']) ?? "";
+		$orderColumn = esc($this->request->getPost('columns')[$orderField]['data']) ?? "";
 		$this->builder->orderBy($orderColumn, $orderAD);
 	}
 


### PR DESCRIPTION
TypeError
Argument 1 passed to CodeIgniter\Database\BaseBuilder::orderBy() must be of the type string, null given, called in
 ../app/Libraries/Datatables.php on line 128

Codeigniter 4.0.3